### PR TITLE
Add composite method in insert for inserting an image with an alpha channel

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -208,33 +208,35 @@ func TestImageWatermarkNoReplicate(t *testing.T) {
 }
 
 func TestImageInsert(t *testing.T) {
-	image := initImage("test.jpg")
-	_, err := image.Crop(800, 600, GravityNorth)
+	var image *Image
+	image = initImage("test.jpg")
+	buf, err := image.Crop(800, 600, GravityNorth)
 	if err != nil {
 		t.Errorf("Cannot process the image: %#v", err)
 	}
 
-	insertImage := initImage("test.jpg")
+	image = NewImage(buf)
+	insertImage := initImage("watermark.png")
 
-	buf, err := image.Insert(Insert{
+	bufInsert, err := image.Insert(Insert{
 		Image: insertImage.buffer,
-		Left:  0,
-		Top:   0,
+		Left:  20,
+		Top:   20,
 	})
 	if err != nil {
 		t.Error(err)
 	}
 
-	err = assertSize(buf, 800, 600)
+	err = assertSize(bufInsert, 800, 600)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if DetermineImageType(buf) != JPEG {
+	if DetermineImageType(bufInsert) != JPEG {
 		t.Fatal("Image is not jpeg")
 	}
 
-	Write("fixtures/test_insert_out.jpg", buf)
+	Write("fixtures/test_insert_out.jpg", bufInsert)
 }
 
 func TestImageZoom(t *testing.T) {

--- a/vips.go
+++ b/vips.go
@@ -523,6 +523,100 @@ func vipsSharpen(image *C.VipsImage, o Sharpen) (*C.VipsImage, error) {
 	return out, nil
 }
 
+func vipsExtractBand(image *C.VipsImage, band, numberOfBands int) (*C.VipsImage, error) {
+	var out *C.VipsImage
+	defer C.g_object_unref(C.gpointer(image))
+
+	err := C.vips_extract_band_bridge(image, &out, C.int(band), C.int(numberOfBands))
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+	return out, nil
+
+}
+
+func vipsLinear1(image *C.VipsImage, a, b float64) (*C.VipsImage, error) {
+	var out *C.VipsImage
+	defer C.g_object_unref(C.gpointer(image))
+
+	err := C.vips_linear1_bridge(image, &out, C.double(a), C.double(b))
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+	return out, nil
+}
+
+func vipsBlack(width, height, bands int) (*C.VipsImage, error) {
+	var out *C.VipsImage
+
+	err := C.vips_black_bridge(&out, C.int(width), C.int(height), C.int(bands))
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+	return out, nil
+}
+
+func vipsAdd(left, right *C.VipsImage) (*C.VipsImage, error) {
+	var out *C.VipsImage
+	defer C.g_object_unref(C.gpointer(left))
+	defer C.g_object_unref(C.gpointer(right))
+
+	err := C.vips_add_bridge(left, right, &out)
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+	return out, nil
+}
+
+func vipsMultiply(left, right *C.VipsImage) (*C.VipsImage, error) {
+	var out *C.VipsImage
+	defer C.g_object_unref(C.gpointer(left))
+	defer C.g_object_unref(C.gpointer(right))
+
+	err := C.vips_multiply_bridge(left, right, &out)
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+	return out, nil
+}
+
+func vipsDivide(left, right *C.VipsImage) (*C.VipsImage, error) {
+	var out *C.VipsImage
+	defer C.g_object_unref(C.gpointer(left))
+	defer C.g_object_unref(C.gpointer(right))
+
+	err := C.vips_divide_bridge(left, right, &out)
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+	return out, nil
+}
+
+func vipsIthenelse(cond, in1, in2 *C.VipsImage, blend bool) (*C.VipsImage, error) {
+	var out *C.VipsImage
+	defer C.g_object_unref(C.gpointer(cond))
+	defer C.g_object_unref(C.gpointer(in1))
+	defer C.g_object_unref(C.gpointer(in2))
+
+	err := C.vips_ifthenelse_bridge(cond, in1, in2, &out, C.int(boolToInt(blend)))
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+	return out, nil
+}
+
+func vipsBandjoin2(in1, in2 *C.VipsImage) (*C.VipsImage, error) {
+	var out *C.VipsImage
+	defer C.g_object_unref(C.gpointer(in1))
+	defer C.g_object_unref(C.gpointer(in2))
+
+	err := C.vips_bandjoin2_bridge(in1, in2, &out)
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+	return out, nil
+}
+
 func max(x int) int {
 	return int(math.Max(float64(x), 0))
 }

--- a/vips.h
+++ b/vips.h
@@ -355,3 +355,43 @@ vips_sharpen_bridge(VipsImage *in, VipsImage **out, int radius, double x1, doubl
 	return vips_sharpen(in, out, "radius", radius, "x1", x1, "y2", y2, "y3", y3, "m1", m1, "m2", m2, NULL);
 #endif
 }
+
+int
+vips_extract_band_bridge(VipsImage *in, VipsImage **out, int band, int number_of_bands) {
+	return vips_extract_band(in, out, band, "n", number_of_bands, NULL);
+}
+
+int
+vips_linear1_bridge(VipsImage *in, VipsImage **out, double a, double b) {
+	return vips_linear1(in, out, a, b, NULL);
+}
+
+int
+vips_black_bridge(VipsImage **out, int width, int height, int bands) {
+	return vips_black(out, width, height, "bands", bands, NULL);
+}
+
+int
+vips_add_bridge(VipsImage *left, VipsImage *right, VipsImage **out) {
+	return vips_add(left, right, out, NULL);
+}
+
+int
+vips_multiply_bridge(VipsImage *left, VipsImage *right, VipsImage **out) {
+	return vips_multiply(left, right, out, NULL);
+}
+
+int
+vips_divide_bridge(VipsImage *left, VipsImage *right, VipsImage **out) {
+	return vips_divide(left, right, out, NULL);
+}
+
+int
+vips_ifthenelse_bridge(VipsImage *cond, VipsImage *in1, VipsImage *in2, VipsImage **out, int blend) {
+	return vips_ifthenelse(cond, in1, in2, out, "blend", blend, NULL);
+}
+
+int
+vips_bandjoin2_bridge(VipsImage *in1, VipsImage *in2, VipsImage **out) {
+	return vips_bandjoin2(in1, in2, out, NULL);
+}


### PR DESCRIPTION
I am now using a custom method  for a true image compositing between the image and the input in the insert method. This is not something that can be found in VIPS but all the inner methods are there.

We can now do an insert of a rgba image in a rgb image.

![test_insert_out](https://cloud.githubusercontent.com/assets/867471/15856702/2b30a808-2c85-11e6-96d1-ce5198e5eb9c.jpg)
